### PR TITLE
Nordwärts

### DIFF
--- a/packages/liedgut/src/songs/nordwaerts.json
+++ b/packages/liedgut/src/songs/nordwaerts.json
@@ -33,6 +33,13 @@
       "mail": "safojasn@aofjnas.de",
       "type": "update",
       "content": "Rechtschreibfehler junge"
+    },
+    {
+      "date": 1667986730432,
+      "name": "Torben",
+      "mail": "torben.poetter@stammvonhelfenstein.de",
+      "type": "update",
+      "content": "Nordwärts ist zweimal in der Datenbank, einmal als \"Norwärts\" und einmal als \"Nordwärts\". Auf den ersten Blick sehen beide aber gleich aus"
     }
   ],
   "translation": [],


### PR DESCRIPTION
Nordwärts ist zweimal in der Datenbank, einmal als "Norwärts" und einmal als "Nordwärts". Auf den ersten Blick sehen beide aber gleich aus

Art: Änderung
Datum: Wed Nov 09 2022 10:38:50 GMT+0100 (Mitteleuropäische Normalzeit)
Eingereicht von: Torben (torben.poetter@stammvonhelfenstein.de)