### PR TITLE
Lumpenbrüderschaft

### DIFF
--- a/packages/liedgut/src/songs/lumpenbruederschaft.json
+++ b/packages/liedgut/src/songs/lumpenbruederschaft.json
@@ -1,0 +1,38 @@
+{
+  "notation": "",
+  "content": "{d}Schnorrer, Penner, {F}schräge Narren, {C}Kesselflicker, {d}Diebe\nfinden im Zi{F}geunerkarren {C}Nachtquartier und {d}Liebe.\n{F}Wo die Karten{d}hexen, fett, {g}ihre Pfeifen {A}paffen\n{d}und im schmieri{F}gen Korsett {C}aus dem Fenster {d}gaffen.\n\nWo die Messer niemals stumpf in die Rippen fahren \nund die Weiber unterm Strumpf ihr Wechselgeld verwahren.\nAbends randaliert das Pack, lange kreist die Flasche,\nund es schmiegt der Bettelsack sich zur Hurentasche\n\nWenn das Feuer knisternd loht, schrumpft die Welt zusammen, \nnur der alte Kunde Tot hockt mit vor den Flammen.\n|:Klagt die Geige herzenswund, schmelzen selbst Gendarmen\nund sie fall'n dem Lumpenhund schluchzend in die Arme. :|",
+  "title": "Lumpenbrüderschaft",
+  "words": [
+    {
+      "name": "Fritz Grasshoff",
+      "nickname": "",
+      "group": "",
+      "organisation": "",
+      "year": ""
+    }
+  ],
+  "tune": [
+    {
+      "name": "Roland Eckert",
+      "nickname": "",
+      "group": "",
+      "organisation": "",
+      "year": ""
+    }
+  ],
+  "translation": [],
+  "beat": "4/4",
+  "alternativeTitle": "",
+  "tempo": "100",
+  "musicalKey": "",
+  "info": "",
+  "changes": [
+    {
+      "date": 1679561548994,
+      "name": "Torben",
+      "mail": "torben.poetter@stammvonhelfenstein.de",
+      "type": "create",
+      "content": ""
+    }
+  ]
+}


### PR DESCRIPTION


Art: Neu hinzugefügt
Datum: Thu Mar 23 2023 09:52:28 GMT+0100 (Mitteleuropäische Normalzeit)
Eingereicht von: Torben (torben.poetter@stammvonhelfenstein.de)