### PR TITLE
Abends treten Elche aus den Dünen

### DIFF
--- a/packages/liedgut/src/songs/abends-treten-elche-aus-den-duenen.json
+++ b/packages/liedgut/src/songs/abends-treten-elche-aus-den-duenen.json
@@ -13,8 +13,8 @@
   ],
   "beat": "4/4",
   "tempo": 60,
-  "info": "",
-  "content": "{a}Abends treten {d}Elche aus den {a}Dünen,\nziehen von der {E}Palve an den {a}Strand.\n/: {d}Wenn die {a}Nacht wie {d}eine gute {a}Mutter leise deckt ihr {E}Tuch auf Haff und {a}Land. :/\n\nRuhig trinken sie vom große Wasser,\ndarin Sterne wie am Himmel stehn.\n/: Und sie heben ihre starken Köpfe, lautlos in des Sommerwindes Weh'n. :/\n\nLangsam schreiten wieder sie von dannen,\nTiere einer längst vergang'nen Zeit.\n/: Und sie schwinden in der Ferne Nebel, wie im hohen Tor der Ewigkeit. :/",
+  "info": "Haff: Lakune, die durch einen Landstreifen fast vollständig vom Meer abgeschlossen ist\nPalve: ostpreußische Bezeichnung für dürres Heideland",
+  "content": "{a}Abends treten {d}Elche aus den {a}Dünen,\nziehen von der {d}Palve {E}an den {a}Strand.\n/: {d}Wenn die {a}Nacht wie {d}eine gute {a}Mutter leise deckt ihr {d}Tuch {E}auf Haff und {a}Land. :/\n\nRuhig trinken sie vom große Wasser,\ndarin Sterne wie am Himmel stehn.\n/: Und sie heben ihre starken Köpfe, lautlos in des Sommerwindes Weh'n. :/\n\nLangsam schreiten wieder sie von dannen,\nTiere einer längst vergang'nen Zeit.\n/: Und sie schwinden in der Ferne Nebel, wie im hohen Tor der Ewigkeit. :/",
   "changes": [
     {
       "name": "Robin Weser",
@@ -28,6 +28,13 @@
       "mail": "chrsitobal@lol.com",
       "type": "update",
       "content": "melodie abends treten elche"
+    },
+    {
+      "date": 1680029480936,
+      "name": "Nicolas Metz (hutmann)",
+      "mail": "Nicolas.metz05@gmail.com",
+      "type": "update",
+      "content": "weiß nicht genau, was hier rein soll, aber die Akkordänderung entnehme ich dem schwarzen Adler, obgleich dieser das einzige Liederbuch in meinem besitz ist, das diese Version aufführt, da ich der Meinung bin, dass das Lied so besser klingt und besser auf die unten angegebene Melodie Passt."
     }
   ],
   "translation": [],


### PR DESCRIPTION
weiß nicht genau, was hier rein soll, aber die Akkordänderung entnehme ich dem schwarzen Adler, obgleich dieser das einzige Liederbuch in meinem besitz ist, das diese Version aufführt, da ich der Meinung bin, dass das Lied so besser klingt und besser auf die unten angegebene Melodie Passt.

Art: Änderung
Datum: Tue Mar 28 2023 20:51:20 GMT+0200 (Mitteleuropäische Sommerzeit)
Eingereicht von: Nicolas Metz (hutmann) (Nicolas.metz05@gmail.com)