### PR TITLE
Die schleßischen Weber

### DIFF
--- a/packages/liedgut/src/songs/die-schlessischen-weber.json
+++ b/packages/liedgut/src/songs/die-schlessischen-weber.json
@@ -22,6 +22,13 @@
       "mail": "robin@bdp-rps.de",
       "type": "create",
       "date": 1585221170355
+    },
+    {
+      "date": 1694439700823,
+      "name": "Torben",
+      "mail": "torben.poetter@stammvonhelfenstein.de",
+      "type": "update",
+      "content": "Das Lied ist doppelt und mit falschem Titel, (schleßisch(falsch) statt schlesisch(richtig)) diese Version hier kann gelöscht werden"
     }
   ],
   "translation": [],


### PR DESCRIPTION
Das Lied ist doppelt und mit falschem Titel, (schleßisch(falsch) statt schlesisch(richtig)) diese Version hier kann gelöscht werden

Art: Änderung
Datum: Mon Sep 11 2023 13:41:40 GMT+0000 (Coordinated Universal Time)
Eingereicht von: Torben (torben.poetter@stammvonhelfenstein.de)