### PR TITLE
Nach Westen

### DIFF
--- a/packages/liedgut/src/songs/nach-westen.json
+++ b/packages/liedgut/src/songs/nach-westen.json
@@ -20,11 +20,12 @@
   ],
   "tune": [
     {
-      "name": "Rudolf Garsk",
+      "name": "Rudolf Scholz, geb Garski",
       "nickname": "",
       "group": "Gau Alt-Burgund",
       "organisation": "VCP",
-      "year": ""
+      "year": "",
+      "critical": false
     }
   ],
   "translation": [],
@@ -47,6 +48,13 @@
       "mail": "",
       "type": "update",
       "content": ""
+    },
+    {
+      "date": 1734386379269,
+      "name": "Kichael",
+      "mail": "kilian@wirsing.be",
+      "type": "update",
+      "content": "Nachname des Autors war als Garsk eingetragen, sollte Garski sein, und er heisst jetzt apparently Rudolf Scholz"
     }
   ],
   "specialSettings": {}


### PR DESCRIPTION
Nachname des Autors war als Garsk eingetragen, sollte Garski sein, und er heisst jetzt apparently Rudolf Scholz

Art: Änderung
Datum: Mon Dec 16 2024 21:59:39 GMT+0000 (Coordinated Universal Time)
Eingereicht von: Kichael (kilian@wirsing.be)