### PR TITLE
Bleib stehn, alte Dampflock

### DIFF
--- a/packages/liedgut/src/songs/bleib-stehn-alte-dampflock.json
+++ b/packages/liedgut/src/songs/bleib-stehn-alte-dampflock.json
@@ -67,6 +67,13 @@
       "mail": "robin@weser.io",
       "type": "update",
       "content": "Settings"
+    },
+    {
+      "date": 1734602811814,
+      "name": "Kichael",
+      "mail": "kilian@wirsing.be",
+      "type": "update",
+      "content": "es heißt Dampflok nicht Dampflock, aber das liegt gibt es schon mit dem richtigen Titel, das hier ist also doppelt"
     }
   ],
   "musicalKey": "Am",


### PR DESCRIPTION
es heißt Dampflok nicht Dampflock, aber das liegt gibt es schon mit dem richtigen Titel, das hier ist also doppelt

Art: Änderung
Datum: Thu Dec 19 2024 10:06:51 GMT+0000 (Coordinated Universal Time)
Eingereicht von: Kichael (kilian@wirsing.be)